### PR TITLE
Remove Closing Tags

### DIFF
--- a/Sources/PortalAdminBlocks.php
+++ b/Sources/PortalAdminBlocks.php
@@ -1022,5 +1022,3 @@ function sportal_admin_block_delete()
 	// Return back to the block list.
 	redirectexit('action=admin;area=portalblocks');
 }
-
-?>

--- a/Sources/PortalAdminCategories.php
+++ b/Sources/PortalAdminCategories.php
@@ -372,5 +372,3 @@ function sportal_admin_category_delete()
 
 	redirectexit('action=admin;area=portalcategories');
 }
-
-?>

--- a/Sources/PortalAdminMain.php
+++ b/Sources/PortalAdminMain.php
@@ -316,5 +316,3 @@ function sportal_information($in_admin = true)
 	$context['sub_template'] = 'information';
 	$context['page_title'] = $txt['sp-info_title'];
 }
-
-?>

--- a/Sources/PortalAdminPages.php
+++ b/Sources/PortalAdminPages.php
@@ -603,5 +603,3 @@ function sportal_admin_page_delete()
 
 	redirectexit('action=admin;area=portalpages');
 }
-
-?>

--- a/Sources/PortalAdminShoutbox.php
+++ b/Sources/PortalAdminShoutbox.php
@@ -557,5 +557,3 @@ function sportal_admin_shoutbox_block_redirect()
 	$context['redirect_message'] = sprintf($txt['sp_admin_shoutbox_block_redirect_message'], $scripturl . '?action=admin;area=portalblocks;sa=add;selected_type=sp_shoutbox;parameters[]=shoutbox;shoutbox=' . $_GET['shoutbox'], $scripturl . '?action=admin;area=portalshoutbox');
 	$context['sub_template'] = 'shoutbox_block_redirect';
 }
-
-?>

--- a/Sources/PortalArticles.php
+++ b/Sources/PortalArticles.php
@@ -183,5 +183,3 @@ function sportal_article()
 	$context['page_title'] = $context['article']['title'];
 	$context['sub_template'] = 'view_article';
 }
-
-?>

--- a/Sources/PortalBlocks.php
+++ b/Sources/PortalBlocks.php
@@ -3457,5 +3457,3 @@ function sp_php($parameters, $id, $return_parameters = false)
 
 	eval($content);
 }
-
-?>

--- a/Sources/PortalCategories.php
+++ b/Sources/PortalCategories.php
@@ -67,5 +67,3 @@ function sportal_category()
 	$context['page_title'] = $context['category']['name'];
 	$context['sub_template'] = 'view_category';
 }
-
-?>

--- a/Sources/PortalMain.php
+++ b/Sources/PortalMain.php
@@ -76,5 +76,3 @@ function sportal_credits()
 	$context['page_title'] = $txt['sp-info_title'];
 	$context['sub_template'] = 'information';
 }
-
-?>

--- a/Sources/PortalPages.php
+++ b/Sources/PortalPages.php
@@ -72,5 +72,3 @@ function sportal_page()
 	$context['page_title'] = $context['SPortal']['page']['title'];
 	$context['sub_template'] = 'view_page';
 }
-
-?>

--- a/Sources/PortalShoutbox.php
+++ b/Sources/PortalShoutbox.php
@@ -111,5 +111,3 @@ function sportal_shoutbox()
 	$context['sub_template'] = 'shoutbox_all';
 	$context['page_title'] = $context['SPortal']['shoutbox']['name'];
 }
-
-?>

--- a/Sources/Subs-Portal.php
+++ b/Sources/Subs-Portal.php
@@ -1645,5 +1645,3 @@ function sp_prevent_flood($type, $fatal = true)
 
 	return false;
 }
-
-?>

--- a/Sources/Subs-PortalAdmin.php
+++ b/Sources/Subs-PortalAdmin.php
@@ -331,5 +331,3 @@ function sp_load_membergroups()
 
 	return $groups;
 }
-
-?>

--- a/Sources/Subs-PortalIntegration.php
+++ b/Sources/Subs-PortalIntegration.php
@@ -137,5 +137,3 @@ function sp_integrate_load_permissions(&$permission_groups, &$permission_list, &
 
 	$left_permission_groups[] = 'sp';
 }
-
-?>

--- a/Themes/default/Portal.template.php
+++ b/Themes/default/Portal.template.php
@@ -281,5 +281,3 @@ function template_block_curve($block)
 	echo '
 	</div>';
 }
-
-?>

--- a/Themes/default/PortalAdmin.template.php
+++ b/Themes/default/PortalAdmin.template.php
@@ -318,5 +318,3 @@ function template_information()
 		<span class="botslice"><span></span></span>
 	</div>';
 }
-
-?>

--- a/Themes/default/PortalAdminArticles.template.php
+++ b/Themes/default/PortalAdminArticles.template.php
@@ -258,5 +258,3 @@ function template_articles_edit()
 		}
 	// ]]></script>';
 }
-
-?>

--- a/Themes/default/PortalAdminBlocks.template.php
+++ b/Themes/default/PortalAdminBlocks.template.php
@@ -574,5 +574,3 @@ function template_block_select_type()
 		</form>
 	</div>';
 }
-
-?>

--- a/Themes/default/PortalAdminCategories.template.php
+++ b/Themes/default/PortalAdminCategories.template.php
@@ -195,5 +195,3 @@ function template_categories_edit()
 		}
 	// ]]></script>';
 }
-
-?>

--- a/Themes/default/PortalAdminPages.template.php
+++ b/Themes/default/PortalAdminPages.template.php
@@ -344,5 +344,3 @@ function template_pages_edit()
 		}
 	// ]]></script>';
 }
-
-?>

--- a/Themes/default/PortalAdminShoutbox.template.php
+++ b/Themes/default/PortalAdminShoutbox.template.php
@@ -344,5 +344,3 @@ function template_shoutbox_block_redirect()
 		</div>
 	</div>';
 }
-
-?>

--- a/Themes/default/PortalArticles.template.php
+++ b/Themes/default/PortalArticles.template.php
@@ -149,5 +149,3 @@ function template_view_article()
 	echo '
 	</div>';
 }
-
-?>

--- a/Themes/default/PortalCategories.template.php
+++ b/Themes/default/PortalCategories.template.php
@@ -90,5 +90,3 @@ function template_view_category()
 	echo '
 	</div>';
 }
-
-?>

--- a/Themes/default/PortalPages.template.php
+++ b/Themes/default/PortalPages.template.php
@@ -137,5 +137,3 @@ function template_view_page_curve()
 				<span class="lowerframe"><span></span></span>';
 	}
 }
-
-?>

--- a/Themes/default/PortalShoutbox.template.php
+++ b/Themes/default/PortalShoutbox.template.php
@@ -282,5 +282,3 @@ function template_shoutbox_xml()
 	echo '
 </smf>';
 }
-
-?>


### PR DESCRIPTION
Closing tags in php are optional and more importantly can cause issues during includes etc ... These days all the cool kids are dropping them as removal is not only harmless, but can be beneficial.   Not sure SMF 2.1 dropped them yet, mostly due to some mods using find ?>, but SP should not have that concern to my knowledge.
